### PR TITLE
Remove changelog check from PR template & codecov version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             python3 -m venv .venv
             . .venv/bin/activate
             make test_requirements
-            make test
+            make test -- --codecov-token=${CODECOV_TOKEN}
   publish_to_pypi:
     docker:
       - image: cimg/python:3.9.13

--- a/makefile
+++ b/makefile
@@ -11,15 +11,18 @@ flake8:
 	flake8 . --exclude=.venv --max-line-length=120
 
 pytest:
-	pytest . --cov=. $(pytest_args) --capture=no
+	pytest . $(pytest_args) --capture=no
 
-CODECOV := \
-	if [ "$$CODECOV_REPO_TOKEN" != "" ]; then \
-	   codecov --token=$$CODECOV_REPO_TOKEN ;\
-	fi
+pytest_codecov:
+	pytest \
+		--junitxml=test-reports/junit.xml \
+		--cov-config=.coveragerc \
+		--cov-report=term \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
 
-test: flake8 pytest
-	$(CODECOV)
+test: flake8 pytest_codecov
 
 publish:
 	rm -rf build dist; \

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 To do (delete all that do not apply):
 
  - [ ] Change has a jira ticket that has the correct status.
- - [ ] Changelog entry added.
+ - [ ] A clear description/pull request message has been added.
  - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
  - [ ] (if updating requirements) Requirements have been compiled.
  - [ ] (if adding env vars) Added any new environment variable to vault.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_cms_client",
-    version="12.0.0",
+    version="12.0.1",
     url="https://github.com/uktrade/directory-cms-client",
     license="MIT",
     author="Department for International Trade",
@@ -16,13 +16,14 @@ setup(
     ],
     extras_require={
         "test": [
-            "codecov==2.1.9",
             "flake8==5.0.4",
             "freezegun==1.0.0",
-            "pytest-cov==2.10.1",
             "pytest-django>=3.8.0,<=4.1.0",
             "pytest-sugar>=0.9.2,<1.0.0",
             "pytest==5.4.0",
+            "pytest-codecov",
+            "pytest-cov",
+            "GitPython",
             "requests_mock==1.8.0",
             "setuptools>=45.2.0,<50.0.0",
             "twine>=3.1.1,<4.0.0",


### PR DESCRIPTION
This PR updates the PR template to no longer mention the changelog as we are no longer mantaining it.

To be able to unblock the CI pipeline, this PR also includes an update to our codecov configuration to use pytest-codecov rather than the outdated codecov

 - [x] Change has a jira ticket that has the correct status.