### PR TITLE
use directory-client-core 7.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [12.0.2](https://pypi.org/project/directory-cms-client/12.0.2/) (2023-07-06)
+[Full Changelog](https://github.com/uktrade/directory-cms-client/pull/59)
+
+**Implemented enhancements:**
+
+- KLS-822 Use at least 7.2.5 of directory-client-core
+
 ## [12.0.1](https://pypi.org/project/directory-cms-client/12.0.1/) (2023-07-05)
 [Full Changelog](https://github.com/uktrade/directory-cms-client/pull/58)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_cms_client",
-    version="12.3.1",
+    version="12.3.2",
     url="https://github.com/uktrade/directory-cms-client",
     license="MIT",
     author="Department for International Trade",
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     install_requires=[
-        "directory_client_core>=7.2.4,<8.0.0",
+        "directory_client_core>=7.2.5,<8.0.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
use at least version 7.2.5 of directory-client-core

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.
 
